### PR TITLE
카드 제작시 이미지 비율 수정

### DIFF
--- a/Traviary/src/components/CreateCard/CreateCard.tsx
+++ b/Traviary/src/components/CreateCard/CreateCard.tsx
@@ -366,6 +366,10 @@ const ImageLabel = styled.label`
 		}
 		width: 85vw;
 		height: 73vw;
+		img {
+			width: auto;
+			height: 100%;
+		}
 	}
 	@media screen and (min-width: 381px) and (max-width: 580px) {
 		width: 85vw;


### PR DESCRIPTION
세로길이가 div길이보다 초과되면 뚫고 나와서 해당 부분 비율 수정 (height에 맞춤)